### PR TITLE
Include drupal_location_id in fake alerts

### DIFF
--- a/main.py
+++ b/main.py
@@ -113,7 +113,8 @@ def poll_location_closure_alerts(logger):
     # If there are no alerts, still record the datetime of the polling, as it
     # may still be required by the LocationClosureAggregator
     if len(records) == 0:
-        records.append({'polling_datetime': str(polling_datetime)})
+        records.append({'drupal_location_id': 'location_closure_alert_poller',
+                       'polling_datetime': str(polling_datetime)})
     encoded_records = avro_encoder.encode_batch(records)
     kinesis_client.send_records(encoded_records)
     kinesis_client.close()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -218,7 +218,8 @@ class TestMain:
         main.main()
 
         mock_avro_encoder.encode_batch.assert_called_once_with(
-            [{'polling_datetime': '2023-01-01 01:23:45-05:00'}])
+            [{'drupal_location_id': 'location_closure_alert_poller',
+              'polling_datetime': '2023-01-01 01:23:45-05:00'}])
         del os.environ['MODE']
 
     def test_poll_location_hours(


### PR DESCRIPTION
The drupal_location_id column in Redshift is non-null. Also, this fake row is purely a safeguard and will realistically never be used, as there is always at least one closure alert.