### PR TITLE
Ignore divisions/centers and allow for multiple names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2025-09-29 -- v2.0.1
+### Fixed
+- Allow for one location id with multiple names
+- Ignore divisions/centers for now
+
 ## 2025-09-03 -- v2.0.0
 ### Added
 - Use new Drupal API instead of deprecated Refinery API

--- a/main.py
+++ b/main.py
@@ -168,25 +168,24 @@ def poll_location_closure_alerts(logger):
         if alert["closing_date_start"] != None:
             location_id = alert["location_codes"]
             location_name = alert["location_names"]
+            if location_id is None and alert["scope"] != "all":
+                # These are centers/divisions and can be ignored
+                continue
+
             if location_id is not None and len(location_id) != 1:
                 logger.error(
                     f"More than one location id listed for alert {alert['id']}: "
                     f"{location_id}"
                 )
                 continue
-            if location_name is not None and len(location_name) != 1:
-                logger.error(
-                    f"More than one location name listed for alert {alert['id']}: "
-                    f"{location_name}"
-                )
-                continue
+
             if alert["extended"] is None:
                 logger.warning(f"NULL 'extended' value for alert {alert['id']}")
             records.append(
                 {
                     "alert_id": alert["id"],
                     "location_id": None if location_id is None else location_id[0],
-                    "name": None if location_name is None else location_name[0],
+                    "name": None if location_name is None else ", ".join(location_name),
                     "closed_for": alert["message_plain"].strip(),
                     "extended_closing": (
                         None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -91,6 +91,7 @@ _TEST_ALERTS_API_RESPONSE = [
         "extended": "false",
         "closing_date_start": "2022-12-31T00:00:00-05:00",
         "closing_date_end": "2023-01-31T00:00:00-05:00",
+        "scope": "location",
     },
     {
         "id": "456",
@@ -100,15 +101,17 @@ _TEST_ALERTS_API_RESPONSE = [
         "extended": "True",
         "closing_date_start": "2022-12-31T00:00:00-05:00",
         "closing_date_end": "2023-01-31T00:00:00-05:00",
+        "scope": "location",
     },
     {
         "id": "789",
         "location_codes": ["libd"],
-        "location_names": ["library d"],
+        "location_names": ["library d", "library e"],
         "message_plain": "extended closure",
         "extended": "true",
         "closing_date_start": "2022-12-31T00:00:00-05:00",
         "closing_date_end": "2023-02-31T00:00:00-05:00",
+        "scope": "location",
     },
     {
         "id": "012",
@@ -118,6 +121,7 @@ _TEST_ALERTS_API_RESPONSE = [
         "extended": "false",
         "closing_date_start": "2023-01-01 00:00:00-05:00",
         "closing_date_end": "2023-01-01 23:59:59-05:00",
+        "scope": "all",
     },
 ]
 
@@ -130,6 +134,7 @@ _TEST_ALERTS_API_WARNING_RESPONSE = [
         "extended": "true",
         "closing_date_start": None,
         "closing_date_end": None,
+        "scope": "location",
     },
     {
         "id": "456",
@@ -139,15 +144,17 @@ _TEST_ALERTS_API_WARNING_RESPONSE = [
         "extended": "true",
         "closing_date_start": "2022-12-31T00:00:00-05:00",
         "closing_date_end": "2023-01-31T00:00:00-05:00",
+        "scope": "location",
     },
     {
         "id": "789",
-        "location_codes": ["liba"],
-        "location_names": ["library a", "library aa"],
+        "location_codes": None,
+        "location_names": None,
         "message_plain": "two names",
         "extended": "true",
         "closing_date_start": "2022-12-31T00:00:00-05:00",
         "closing_date_end": "2023-01-31T00:00:00-05:00",
+        "scope": "location",
     },
     {
         "id": "012",
@@ -157,6 +164,7 @@ _TEST_ALERTS_API_WARNING_RESPONSE = [
         "extended": None,
         "closing_date_start": "2022-12-31T00:00:00-05:00",
         "closing_date_end": "2023-01-31T00:00:00-05:00",
+        "scope": "location",
     },
 ]
 
@@ -192,7 +200,7 @@ _AVRO_ALERTS_INPUT = [
     {
         "alert_id": "789",
         "location_id": "libd",
-        "name": "library d",
+        "name": "library d, library e",
         "closed_for": "extended closure",
         "extended_closing": True,
         "alert_start": "2022-12-31 00:00:00-05:00",
@@ -304,10 +312,6 @@ class TestMain:
         assert (
             "More than one location id listed for alert 456: ['liba', 'libaa']"
             in caplog.text
-        )
-        assert (
-            "More than one location name listed for alert 789: ['library a', "
-            "'library aa']" in caplog.text
         )
         assert "NULL 'extended' value for alert 012" in caplog.text
         mock_avro_encoder.encode_batch.assert_called_once_with(


### PR DESCRIPTION
A location can have multiple names if it contains divisions -- e.g. when all of LPA is closed, the names include "Library of the Performing Arts" as well as "Jerome Robbins Dance Division" etc. In the future we would like to collect division/center hours as well, which would help solve this problem, but we need to figure out how to standardize the ids first.